### PR TITLE
Fix completion of dir local prefixed environments

### DIFF
--- a/_conda
+++ b/_conda
@@ -195,7 +195,7 @@ __conda_envs(){
 
     # unmaned envs (if show-unammed).
     if test -n "$unnamed"; then
-        envs+=($( (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' ' | sed -e "s|^$localenvspath/||"))
+        envs+=($( (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' ' | sed -e "s|^${PWD}|.|" | sed -e "s|^$localenvspath/||"))
     fi
 
     _describe $describe_opts -t envs 'conda environments' envs


### PR DESCRIPTION
Fixes #54 by replacing the current directory path in the enviromnent path with '.'

This seems to work reasonably well.