### PR TITLE
Improvements in completion usability

### DIFF
--- a/_conda
+++ b/_conda
@@ -204,7 +204,7 @@ __conda_envs(){
 
     # unmaned envs (if show-unammed).
     if test -n "$unnamed"; then
-        envs+=($( (test -n "$unnamed" && cat ${HOME:?}/.conda/environments.txt) | cut -f1 -d' ' | sed -e "s|^${PWD}|.|" | sed -e "s|^$localenvspath/||"))
+        envs+=($( (cat ${HOME:?}/.conda/environments.txt) 2>/dev/null | cut -f1 -d' ' | sed -e "s|^${PWD}|.|" | sed -e "s|^$localenvspath/||"))
     fi
 
     _describe $describe_opts -t envs 'conda environments' envs
@@ -746,4 +746,3 @@ case $state in
     esac
     ;;
 esac
-

--- a/_conda
+++ b/_conda
@@ -462,7 +462,7 @@ json_opts=(
 
 env_opts=(
     '(-n --name -p --prefix)'{-n,--name}'[name of environment]:environment:__conda_envs' \
-    '(-n --name -p --prefix)'{-p,--prefix}'[full path to environment prefix]:path:_path_files' \
+    '(-n --name -p --prefix)'{-p,--prefix}'[full path to environment prefix]:prefix:_directories' \
     )
 
 channel_opts=(
@@ -739,7 +739,7 @@ case $state in
     (activate)
             _arguments -C $help_opts \
                           '--stack[activate this environment on top of the previous environment]' \
-                          '*:environment:{__conda_envs; _path_files}'
+                          '*:environment:{__conda_envs; _directories}'
                     ;;
     (deactivate)
             _arguments -C $help_opts \

--- a/_conda
+++ b/_conda
@@ -703,18 +703,19 @@ case $state in
                 (create)
                     _arguments -C $help_opts \
                                   $json_opts \
-                                  '(-n --name)'{-n,--name}'[name of environment]:environment:__conda_envs' \
+                                  $env_opts \
                                   '(-f --file)'{-f,--file}'[environment definition]:file:_path_files' \
                                   '(-q --quiet)'{-q,--quiet}'[]' \
                     ;;
                 (export)
                     _arguments -C $help_opts \
-                                  '(-n --name)'{-n,--name}'[name of environment]:environment:__conda_envs' \
+                                  $env_opts \
                                   '(-f --file)'{-f,--file}'[]:file:_path_files' \
                     ;;
                 (list)
                     _arguments -C $help_opts \
                                   $json_opts \
+                                  $env_opts
                     ;;
                 (remove)
                     _arguments -C $help_opts \
@@ -727,7 +728,7 @@ case $state in
                 (update)
                     _arguments -C $help_opts \
                                   $json_opts \
-                                  '(-n --name)'{-n,--name}'[name of environment]:environment:__conda_envs' \
+                                  $env_opts \
                                   '(-f --file)'{-f,--file}'[environment definition]:file:_path_files' \
                                   '(-q --quiet)'{-q,--quiet}'[]' \
                     ;;
@@ -738,7 +739,7 @@ case $state in
     (activate)
             _arguments -C $help_opts \
                           '--stack[activate this environment on top of the previous environment]' \
-                          '*:environment:__conda_envs'
+                          '*:environment:{__conda_envs; _path_files}'
                     ;;
     (deactivate)
             _arguments -C $help_opts \


### PR DESCRIPTION
Hi, I was updating my fork of this repo for better usability, and now decided to backport some of the changes.

Highlights:

- Silence warnings if `~/.conda/environments.txt` is not found.
- Add missing `--prefix` options to some of the `conda env` subcommands.
- Also complete for prefixes in `conda activate` subcommand.
- For the `--prefix` arg, complete only for directories.