### PR TITLE
Add support for miniconda installations via homebrew

### DIFF
--- a/_conda
+++ b/_conda
@@ -168,6 +168,7 @@ local -A opt_args
 
 __conda_envs(){
     local -a envs unnamed sort globalfirst localenvs globalenvs
+    local -a conda_path
     local -a ls_opts
     local -a describe_opts
     local localenvspath
@@ -182,8 +183,16 @@ __conda_envs(){
         describe_opts+=("-V")
     fi
 
+    conda_exec=$(which conda)
+
+    if test ${${conda_exec}#*"homebrew"} != ${conda_exec}; then
+        conda_path="/opt/homebrew/Caskroom/miniconda/base/envs"
+    else
+        conda_path="${${CONDA_EXE}%bin/conda}/envs"
+    fi
+
     # global envs (if exists) and base env.
-    globalenvs=($([[ -d "${${CONDA_EXE}%bin/conda}/envs" ]] && ls $ls_opts ${${CONDA_EXE}%bin/conda}/envs))
+    globalenvs=($([[ -d "${conda_path}" ]] && ls $ls_opts ${conda_path}))
     globalenvs+=("base")
 
     # local envs (if exists).

--- a/_conda
+++ b/_conda
@@ -185,7 +185,7 @@ __conda_envs(){
 
     conda_exec=$(which conda)
 
-# Detect homebrew installations and set path accordingly.
+    # Detect homebrew installations and set path accordingly.
     if [[ ${${conda_exec}#*"homebrew"} != ${conda_exec} ]]; then
         conda_path="/opt/homebrew/Caskroom/miniconda/base/envs"
     else

--- a/_conda
+++ b/_conda
@@ -185,7 +185,8 @@ __conda_envs(){
 
     conda_exec=$(which conda)
 
-    if test ${${conda_exec}#*"homebrew"} != ${conda_exec}; then
+# Detect homebrew installations and set path accordingly.
+    if [[ ${${conda_exec}#*"homebrew"} != ${conda_exec} ]]; then
         conda_path="/opt/homebrew/Caskroom/miniconda/base/envs"
     else
         conda_path="${${CONDA_EXE}%bin/conda}/envs"


### PR DESCRIPTION
Added support for miniconda installations via homebrew by checking, if the conda executable is installed on a homebrew path, i.e. `/opt/homebrew/bin/conda`.

In this case, `/opt/homebrew/Caskroom/miniconda/base/envs` should be used as the global environments path.