### PR TITLE
update conda search completion

### DIFF
--- a/_conda
+++ b/_conda
@@ -562,7 +562,7 @@ case $state in
                       '--platform[Search the given platform.]' \
                       '--spec[Treat regex argument as a package specification]' \
                       '(-i --info)'{-v,--verbose}'[Provide detailed information about each package.]' \
-                      '*:packages:__magic' \
+                      '*:regex:' \
         ;;
     (create)
         _arguments -C $help_opts \

--- a/_conda
+++ b/_conda
@@ -561,7 +561,8 @@ case $state in
                       '(-v --verbose)'{-v,--verbose}'[Show available packages as blocks of data]' \
                       '--platform[Search the given platform.]' \
                       '--spec[Treat regex argument as a package specification]' \
-                      '*:regex:' \
+                      '(-i --info)'{-v,--verbose}'[Provide detailed information about each package.]' \
+                      '*:packages:__magic' \
         ;;
     (create)
         _arguments -C $help_opts \


### PR DESCRIPTION
Add completion of `-i|--info` flags for conda search.

Enable `conda search` to complete packages and versions.

Following discussion at: https://github.com/conda-incubator/conda-zsh-completion/issues/60